### PR TITLE
Closes #28 #29 - Downcase username; Allow username for sign in

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -22,6 +22,8 @@ skeleton:skeleton
 less
 accounts-base
 accounts-password
+useraccounts:unstyled
+useraccounts:flow-routing
 kadira:flow-router
 kadira:blaze-layout
 arillo:flow-router-helpers
@@ -29,3 +31,4 @@ themeteorchef:bert
 reactive-var
 momentjs:moment
 reywood:publish-composite
+fortawesome:fontawesome

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -72,6 +72,7 @@ service-configuration@1.0.5
 session@1.1.1
 sha@1.0.4
 skeleton:skeleton@2.0.4
+softwarerero:accounts-t9n@1.1.4
 spacebars@1.0.7
 spacebars-compiler@1.0.7
 srp@1.0.4
@@ -83,6 +84,9 @@ tracker@1.0.9
 ui@1.0.8
 underscore@1.0.4
 url@1.0.5
+useraccounts:core@1.12.4
+useraccounts:flow-routing@1.12.4
+useraccounts:unstyled@1.12.4
 webapp@1.2.3
 webapp-hashing@1.0.5
 zimme:active-route@2.3.2

--- a/client/lib/accounts/config.js
+++ b/client/lib/accounts/config.js
@@ -1,0 +1,101 @@
+/*
+ * Useraccounts configuration.
+ *
+ */
+AccountsTemplates.configure({
+    defaultLayout: 'layout',
+    defaultLayoutRegions: {
+        header: 'header'//,
+        //footer: '_footer'
+    },
+    defaultContentRegion: 'main',
+    showForgotPasswordLink: true,
+    overrideLoginErrors: true,
+    enablePasswordChange: true,
+    sendVerificationEmail: true,
+    lowercaseUsername: false,
+
+    //enforceEmailVerification: true,
+    confirmPassword: true,
+    continuousValidation: true,
+    //displayFormLabels: true,
+    //forbidClientAccountCreation: false,
+    homeRoutePath: '/',
+    //showAddRemoveServices: false,
+    showPlaceholders: true,
+
+    negativeValidation: true,
+    positiveValidation: true,
+    negativeFeedback: false,
+    positiveFeedback: false,
+
+    // Privacy Policy and Terms of Use
+    // privacyUrl: 'privacy',
+    // termsUrl: 'terms',
+
+    // Form texts
+    texts: {
+      title: {
+        changePwd: "Change password",
+        forgotPwd: "Forgot password?",
+        resetPwd: "Reset password",
+        signIn: "Sign in",
+        signUp: "Sign up",
+        verifyEmail: "Verify Email",
+      },
+      button: {
+        changePwd: "Change password",
+        enrollAccount: "Enroll Text",
+        forgotPwd: "Send reset link",
+        resetPwd: "Reset Password",
+        signIn: "Sign in",
+        signUp: "Sign up",
+      }
+    }
+});
+
+/*
+ * Configuring useraccounts for login
+ * with both username or email.
+ *
+ * https://github.com/meteor-useraccounts/core/blob/master/Guide.md#login-with-username-or-email
+ */
+let pwd = AccountsTemplates.removeField('password');
+AccountsTemplates.removeField('email');
+AccountsTemplates.addFields([
+  {
+    _id: 'email',
+    type: 'email',
+    required: true,
+    displayName: "Email",
+    re: /.+@(.+){2,}\.(.+){2,}/,
+    errStr: 'Invalid email',
+  },
+  {
+    _id: "username",
+    type: "text",
+    displayName: "Username",
+    required: true,
+    minLength: 4,
+  },
+  {
+    _id: 'username_and_email',
+    placeholder: 'Username or email',
+    type: 'text',
+    required: true,
+    displayName: "Login",
+  },
+  pwd
+]);
+
+/*
+ * Enable preconfigured Flow-Router routes by useraccounts:flow-router.
+ *
+ */
+AccountsTemplates.configureRoute('changePwd');
+AccountsTemplates.configureRoute('forgotPwd');
+AccountsTemplates.configureRoute('resetPwd');
+AccountsTemplates.configureRoute('signIn');
+AccountsTemplates.configureRoute('signUp');
+AccountsTemplates.configureRoute('verifyEmail');
+// AccountsTemplates.configureRoute('enrollAccount'); // for creating passwords after logging first time

--- a/client/stylesheets/main.less
+++ b/client/stylesheets/main.less
@@ -3,3 +3,6 @@
 @import 'modules/header.import.less';
 @import 'modules/navigation.import.less';
 @import 'modules/posts.import.less';
+
+// Keep it at the bottom
+@import 'modules/useraccounts.import.less';

--- a/client/stylesheets/modules/useraccounts.import.less
+++ b/client/stylesheets/modules/useraccounts.import.less
@@ -1,0 +1,36 @@
+.at-title h3 {
+	font-size: 5rem;
+	font-weight: 300;
+	line-height: 1.2;
+	letter-spacing: -0.1rem;
+	text-align: center;
+}
+.at-input input {
+	width: 100%;
+}
+.at-btn.submit {
+	color: #FFF;
+	background-color: #33C3F0 !important;
+	outline: 0px none;
+	display: inline-block;
+	width: 100%;
+	height: 38px;
+	padding: 0px 30px;
+	text-align: center;
+	font-size: 11px;
+	font-weight: 600;
+	line-height: 38px;
+	letter-spacing: 0.1rem;
+	text-transform: uppercase;
+	text-decoration: none;
+	white-space: nowrap;
+	background-color: transparent;
+	border-radius: 4px;
+	border: 1px solid #33C3F0;
+	cursor: pointer;
+	box-sizing: border-box;
+}
+.at-error {
+	text-align: center;
+	color: #D43939;
+}

--- a/client/views/header.html
+++ b/client/views/header.html
@@ -7,7 +7,7 @@
         </li>
         {{#if currentUser}}
           <li class="u-pull-right">
-            <a href="{{pathFor 'signOut'}}"><i class="fa fa-power-off fa-lg"></i></a>
+            <a class="user-logout-link" href="#"><i class="fa fa-power-off fa-lg"></i></a>
           </li>
         {{/if}}
       </ul>

--- a/client/views/header.js
+++ b/client/views/header.js
@@ -1,0 +1,11 @@
+Template.header.events({
+  'click .user-logout-link': function() {
+    Meteor.logout(function(error){
+      if(error){
+        alert(error.reason);
+      } else {
+        FlowRouter.go('/sign-in')
+      }
+    });
+  },
+});

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,44 +1,7 @@
 publicAccessible = FlowRouter.group({});
 
 signInRequired = FlowRouter.group({
-  triggersEnter: [
-    () => {
-      if (!(Meteor.loggingIn() || Meteor.userId())) {
-        FlowRouter.go('signIn');
-      } else if (Meteor.user()) {
-        FlowRouter.go('/');
-      }
-    }
-  ]
-});
-
-publicAccessible.route('/sign-up', {
-  name: 'signUp',
-  action: () => {
-    setTitle('Sign up');
-    BlazeLayout.render('layout', {
-      main: 'signUp'
-    });
-  }
-});
-
-publicAccessible.route('/sign-in', {
-  name: 'signIn',
-  action: () => {
-    setTitle('Sign in');
-    BlazeLayout.render('layout', {
-      main: 'signIn'
-    });
-  }
-});
-
-publicAccessible.route('/sign-out', {
-  name: 'signOut',
-  action: () => {
-    Meteor.logout(() => {
-      FlowRouter.go('signIn');
-    });
-  }
+  triggersEnter: [AccountsTemplates.ensureSignedIn]
 });
 
 signInRequired.route('/', {


### PR DESCRIPTION
1. Added packages:
 - useraccounts:unstyled
 - useraccounts:flow-routing
 - fortawesome:fontawesome

2. Added useraccounts configuration files into `client/lib/accounts`
3. From line 63 to 89 in `client/lib/accounts/config.js`, enabled creating accounts with email and username, also that will create third field `username_and_field` which will help when signing-in with both username or email - followed guide from here: https://github.com/meteor-useraccounts/core/blob/master/Guide.md#login-with-username-or-email
4. From line 95 to 100 in `client/lib/accounts/config.js`, added preconfigured routes for `sign-up`, `sign-in`, `change-password`, `forgot-password` and `verify-email`. 
5. Styled sign up/sign in/reset password and other useraccounts forms to match skeleton styles (forms uses different class names).
6. Refractored logout - moved it from routes to `client/views/header.js` template event, it logouts and redirects to /sign-in

...After this merge, we can implement sending emails (useraccounts have this bundled, just waits for email settings on the server)